### PR TITLE
fix: 리워드 환급 요청 전송 및 에러 메세지 수신 에러 수정

### DIFF
--- a/src/pages/RewardRefundPage.jsx
+++ b/src/pages/RewardRefundPage.jsx
@@ -1,41 +1,36 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import backButton from "../assets/back-btn.png";
 import "../styles/RewardRefund.css";
-import axios from "axios";
+import api from "../service/api";
 
 export default function RewardRefund() {
-  const [rewardAmount, setRewardAmount] = useState(0); // 서버에서 받아오는 리워드
   const navigate = useNavigate();
   const [bankOpen, setBankOpen] = useState(false);
   const [selectedBank, setSelectedBank] = useState("은행 선택");
   const [amount, setAmount] = useState("");
   const [accountNumber, setAccountNumber] = useState("");
-  const [amountError, setAmountError] = useState("");
   const [holderName, setHolderName] = useState("");
+  const [amountError, setAmountError] = useState("");
+  const [serverErrorMessage, setServerErrorMessage] = useState("");
 
   const banks = ["국민은행", "우리은행", "농협은행", "신한은행", "IBK은행"];
 
-  // 서버에서 리워드 불러오기
-  useEffect(() => {
-    axios
-      .get("/api/user/reward")
-      .then((res) => setRewardAmount(res.data.reward))
-      .catch((err) => console.error(err));
-  }, []);
-
   const handleRefundRequest = async () => {
-    if (Number(amount) <= 0 || Number(amount) > rewardAmount) {
-      alert("잘못된 금액입니다.");
+    setServerErrorMessage("");
+
+    if (Number(amount) <= 0) {
+      setServerErrorMessage("잘못된 금액입니다.");
       return;
     }
+
     if (!selectedBank || !accountNumber || !holderName) {
-      alert("은행, 계좌번호, 예금주를 입력하세요.");
+      setServerErrorMessage("은행, 계좌번호, 예금주를 입력하세요.");
       return;
     }
 
     try {
-      await axios.post("api/users/user/reward", {
+      await api.post("/api/users/user/reward", {
         amount,
         bankName: selectedBank,
         bankAccount: accountNumber,
@@ -44,7 +39,9 @@ export default function RewardRefund() {
       alert("정상 환급 되었습니다.");
       navigate("/mypage");
     } catch (err) {
-      alert("신청 실패: " + err.response?.data?.message);
+      const message =
+        err.response?.data?.message || "알 수 없는 오류가 발생했습니다.";
+      setServerErrorMessage(message);
     }
   };
 
@@ -90,7 +87,6 @@ export default function RewardRefund() {
         {amountError && <div className="error-message">{amountError}</div>}
       </div>
 
-      {/* 환급 계좌 입력 */}
       <div className="form-group">
         <label className="form-label">
           환급 계좌<span className="required">*</span>
@@ -145,10 +141,13 @@ export default function RewardRefund() {
         />
       </div>
 
-      {/* 환급 버튼 */}
+      {serverErrorMessage && (
+        <div className="error-message server-error">{serverErrorMessage}</div>
+      )}
+
       <button
         className="submit-button"
-        disabled={!amount || Number(amount) < 1000}
+        disabled={!amount}
         onClick={handleRefundRequest}
       >
         환급하기


### PR DESCRIPTION
## 관련 이슈

- 이슈: #12 

## 📑 작업 상세 내용
- 사용자가 보유 금액보다 많은 환급 금액을 요청하는 등 서버에서 에러 메세지가 발생했을 때, 프론트에서 확인할 수 있도록 에러메세지 전송
- post 전송 오류 해결

## 💫 작업 요약
- 환급 요청 페이지 RewardRefund.Jsx 버튼 활성화 값 수정
- 프론트에서 에러 메세지 확인 가능

## 🔍 집중적으로 리뷰할 부분 (확인 및 점검 사항)

## 📜 참고 자료(선택) 