### PR TITLE
Feat: 메인페이지 및 심부름 관련 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@mui/icons-material": "^7.0.2",
         "@mui/material": "^7.0.2",
         "@mui/system": "^7.0.2",
+        "@mui/x-date-pickers": "^8.3.0",
         "axios": "^1.9.0",
         "cra-template": "1.3.0",
         "dayjs": "^1.11.13",
@@ -3177,6 +3178,92 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
       "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
       "license": "MIT"
+    },
+    "node_modules/@mui/x-date-pickers": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-8.3.0.tgz",
+      "integrity": "sha512-N4Rw/Q6bAHBj7BpLEGE84MG05B56wWQStZch9NqA0U8vTt9TGvkj27fQaboOIikk6ERQTHM2mMoLZgwQAvlhIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1",
+        "@mui/utils": "^7.0.2",
+        "@mui/x-internals": "8.3.0",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
+        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
+        "dayjs": "^1.10.7",
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2 || ^3.0.0",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "date-fns-jalali": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-internals": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.3.0.tgz",
+      "integrity": "sha512-wSVxg5aSO9xvJT7oarhsXqr03NeP355Whm7Qn6z3VvxdGwNc7K7vKpez3E+2KMxtdvywOmragwlSdTaO1K6qkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1",
+        "@mui/utils": "^7.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/system": "^7.0.2",
         "axios": "^1.9.0",
         "cra-template": "1.3.0",
+        "dayjs": "^1.11.13",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.5.3",
@@ -6331,6 +6332,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@mui/icons-material": "^7.0.2",
     "@mui/material": "^7.0.2",
     "@mui/system": "^7.0.2",
+    "@mui/x-date-pickers": "^8.3.0",
     "axios": "^1.9.0",
     "cra-template": "1.3.0",
     "dayjs": "^1.11.13",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@mui/system": "^7.0.2",
     "axios": "^1.9.0",
     "cra-template": "1.3.0",
+    "dayjs": "^1.11.13",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.5.3",

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,8 @@ import Layout from "./layout/Layout";
 import Home from "./pages/Home";
 import Chat from "./pages/Chat";
 import MyPage from "./pages/MyPage";
+import TaskDetail from "./pages/TaskDetail";
+import TaskWrite from "./pages/TaskWrite";
 import Login from "./pages/LoginPage";
 import OAuthRedirctHandler from "./pages/OAuthRedirectHandler";
 import ExtraInfo from "./pages/ExtraInfoPage";
@@ -18,6 +20,8 @@ function App() {
           <Route path="/" element={<Home />} />
           <Route path="/chat" element={<Chat />} />
           <Route path="/mypage" element={<MyPage />} />
+          <Route path="/task/:id" element={<TaskDetail />} />
+          <Route path="/write" element={<TaskWrite />} />
           <Route path="/login" element={<Login />} />
           <Route
             path="/login/oauth2/code/kakao"

--- a/src/components/TaskItem/TaskItem.js
+++ b/src/components/TaskItem/TaskItem.js
@@ -1,0 +1,22 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import styles from "../../styles/TaskItem.module.css";
+
+export default function TaskItem({ post }) {
+  const navigate = useNavigate();
+
+  return (
+    <div
+      className={styles.container}
+      onClick={() => navigate(`/posts/${post.id}`)}
+    >
+      <img src={post.image} alt={post.title} className={styles.thumbnail} />
+      <div className={styles.info}>
+        <h2 className={styles.title}>{post.title}</h2>
+        <p className={styles.meta}>
+          <div>{post.time}</div> <div>{post.amount}</div>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import TaskItem from "../components/TaskItem/TaskItem";
 import styles from "../styles/Home.module.css";
@@ -17,7 +17,7 @@ export default function Home() {
   const [hasNext, setHasNext] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
 
-  const loadPosts = async () => {
+  const loadPosts = useCallback(async () => {
     if (!hasNext || isLoading) return;
     setIsLoading(true);
     try {
@@ -46,7 +46,7 @@ export default function Home() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [cursor, hasNext, isLoading]);
 
   // fetch user profile once
   useEffect(() => {
@@ -66,7 +66,7 @@ export default function Home() {
   // initial load
   useEffect(() => {
     loadPosts();
-  }, []);
+  }, [loadPosts, hasNext, isLoading]);
 
   // infinite scroll
   useEffect(() => {
@@ -82,7 +82,7 @@ export default function Home() {
     };
     window.addEventListener("scroll", onScroll);
     return () => window.removeEventListener("scroll", onScroll);
-  }, [cursor, hasNext, isLoading]);
+  }, [loadPosts, hasNext, isLoading]);
 
   return (
     <>

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,9 +1,131 @@
-function Home() {
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import TaskItem from "../components/TaskItem/TaskItem";
+import styles from "../styles/Home.module.css";
+import logo from "../assets/logo.png";
+import api from "../service/api";
+
+const PAGE_SIZE = 7;
+
+export default function Home() {
+  const navigate = useNavigate();
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [userAddress, setUserAddress] = useState("");
+
+  const [posts, setPosts] = useState([]);
+  const [cursor, setCursor] = useState(null);
+  const [hasNext, setHasNext] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const loadPosts = async () => {
+    if (!hasNext || isLoading) return;
+    setIsLoading(true);
+    try {
+      const params = { size: PAGE_SIZE };
+      if (cursor) {
+        params.cursor = cursor;
+      }
+
+      const res = await api.get("/api/tasks", { params });
+      const { items = [], nextCursor, hasNext: next } = res.data;
+      console.log("Fetched tasks data:", res.data);
+
+      const mapped = items.map((item) => ({
+        id: item.taskId,
+        image: item.imageUrl || logo,
+        title: item.title,
+        time: item.deadline,
+        amount: `₩${Number(item.reward).toLocaleString()}`,
+      }));
+
+      setPosts((prev) => [...prev, ...mapped]);
+      setCursor(nextCursor);
+      setHasNext(next);
+    } catch (err) {
+      console.error("Failed to load tasks", err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // fetch user profile once
+  useEffect(() => {
+    api
+      .get("/api/users/user/profile")
+      .then((res) => {
+        setIsLoggedIn(true);
+        setUserAddress(res.data.address);
+      })
+      .catch((err) => {
+        if (err.response?.status === 401) {
+          setIsLoggedIn(false);
+        }
+      });
+  }, []);
+
+  // initial load
+  useEffect(() => {
+    loadPosts();
+  }, []);
+
+  // infinite scroll
+  useEffect(() => {
+    const onScroll = () => {
+      if (
+        hasNext &&
+        !isLoading &&
+        window.innerHeight + window.pageYOffset + 100 >=
+          document.body.offsetHeight
+      ) {
+        loadPosts();
+      }
+    };
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [cursor, hasNext, isLoading]);
+
   return (
-    <div style={{ width: "100%" }}>
-      <h1>Home</h1>
-    </div>
+    <>
+      <header className={styles.header}>
+        <img
+          src={logo}
+          alt="당심 로고"
+          className={styles.logo}
+          onClick={() => navigate("/")}
+          style={{ cursor: "pointer" }}
+        />
+        <div className={styles.userArea}>
+          {isLoggedIn ? (
+            <span className={styles.userInfo}>{userAddress}</span>
+          ) : (
+            <button
+              className={styles.loginButton}
+              onClick={() => navigate("/login")}
+            >
+              로그인
+            </button>
+          )}
+        </div>
+      </header>
+
+      <main className={styles.container}>
+        {posts.map((post) => (
+          <div
+            key={post.id}
+            onClick={() => navigate(`/task/${post.id}`)}
+            style={{ cursor: "pointer" }}
+          >
+            <TaskItem post={post} />
+          </div>
+        ))}
+
+        <button
+          className={styles.writeButton}
+          onClick={() => navigate("/write")}
+        >
+          + 작성하기
+        </button>
+      </main>
+    </>
   );
 }
-
-export default Home;

--- a/src/pages/TaskDetail.js
+++ b/src/pages/TaskDetail.js
@@ -1,0 +1,57 @@
+import React from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import "../styles/TaskDetail.css";
+import logo from "../assets/logo.png";
+
+export default function TaskDetail() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  // 임시 더미 데이터 (나중에 API 연동)
+  const post = {
+    image: logo,
+    title: `게시글 제목 ${id}`,
+    time: "2025-05-07 10:00",
+    amount: "₩10,000",
+    location: "서울 강남구",
+    description: `
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+      Vivamus lacinia odio vitae vestibulum vestibulum. 
+      Cras venenatis euismod malesuada. 
+      Donec fermentum, urna vitae aliquet mollis, 
+      nisl risus malesuada urna, a posuere dolor magna a orci.
+    `,
+    stats: "미배정2", // 미배정, 배정됨 등
+    isMyTask: false, // 사용자가 작성한 글인지 여부
+  };
+
+  const isActive = post.stats === "미배정" && post.isMyTask === false;
+
+  return (
+    <div className="task-detail-container">
+      {/* <header className="task-detail-header"> */}
+      <button className="task-detail-back-button" onClick={() => navigate("/")}>
+        ← 뒤로
+      </button>
+      {/* </header> */}
+
+      <img src={post.image} alt={post.title} className="task-detail-image" />
+
+      <div className="task-detail-content">
+        <h1 className="task-detail-title">{post.title}</h1>
+        <p className="task-detail-time">{post.time}</p>
+        <p className="task-detail-amount">{post.amount}</p>
+        <p className="task-detail-location">{post.location}</p>
+        <p className="task-detail-description">{post.description}</p>
+      </div>
+
+      <button
+        className={`task-detail-action-button${isActive ? "" : " disabled"}`}
+        onClick={isActive ? () => navigate("/chat") : undefined}
+        disabled={!isActive}
+      >
+        {isActive ? "심부름 하기" : "신청 마감"}
+      </button>
+    </div>
+  );
+}

--- a/src/pages/TaskWrite.js
+++ b/src/pages/TaskWrite.js
@@ -1,0 +1,137 @@
+"use client";
+
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import dayjs from "dayjs";
+import { DemoContainer } from "@mui/x-date-pickers/internals/demo";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { DateTimePicker } from "@mui/x-date-pickers/DateTimePicker";
+import "../styles/TaskWrite.css";
+import api from "../service/api";
+
+export default function TaskWrite() {
+  const navigate = useNavigate();
+  const [images, setImages] = useState([]);
+  const [title, setTitle] = useState("");
+  const [amount, setAmount] = useState("");
+  const [deadline, setDeadline] = useState(dayjs().add(30, "minute"));
+  const [location, setLocation] = useState("");
+
+  const handleImageChange = (e) => {
+    const files = Array.from(e.target.files).slice(0, 3);
+    setImages(files);
+  };
+
+  const handleSubmit = async () => {
+    if (!isFormValid) return;
+    try {
+      const body = {
+        title: title.trim(),
+        content: title.trim(), // TODO: 본문 입력 칸 추가 필요
+        deadline: deadline.format("YY.MM.DD HH:mm"),
+        reward: Number(amount),
+        address: location.trim(),
+        imageUrls: [], // TODO: 이미지 업로드 후 URL 배열로 대체
+      };
+      const res = await api.post("/api/tasks/task", body);
+      const { taskId, merchantUid, result } = res.data;
+      if (result) {
+        navigate(`/task/${taskId}`);
+      } else {
+        alert("심부름 요청에 실패했습니다.");
+      }
+    } catch (err) {
+      console.error("Failed to create task", err);
+      alert("심부름 요청 중 오류가 발생했습니다.");
+    }
+  };
+
+  const isFormValid =
+    title.trim() !== "" &&
+    amount !== "" &&
+    !isNaN(amount) &&
+    Number(amount) >= 100 &&
+    Number(amount) <= 1000000 &&
+    deadline.isValid() &&
+    dayjs().add(30, "minute").isBefore(deadline) &&
+    location.trim() !== "";
+
+  return (
+    <div className="task-detail-container">
+      <header className="task-detail-header">
+        <button
+          className="task-detail-back-button"
+          onClick={() => navigate(-1)}
+        >
+          ← 뒤로
+        </button>
+      </header>
+
+      <div className="task-write-container">
+        <div className="form-group">
+          <label>사진 업로드 (최대 3장)</label>
+          <input
+            type="file"
+            accept="image/*"
+            multiple
+            onChange={handleImageChange}
+          />
+        </div>
+
+        <div className="form-group">
+          <label>심부름 명</label>
+          <input
+            type="text"
+            value={title}
+            placeholder="심부름 명을 입력하세요"
+            onChange={(e) => setTitle(e.target.value)}
+          />
+        </div>
+
+        <div className="form-group">
+          <label>심부름 보상 금액</label>
+          <input
+            type="number"
+            value={amount}
+            placeholder="100 ~ 1,000,000"
+            onChange={(e) => setAmount(e.target.value)}
+            min={100}
+            max={1000000}
+          />
+        </div>
+
+        <div className="form-group">
+          <label>심부름 수행 마감 시간</label>
+          <LocalizationProvider dateAdapter={AdapterDayjs}>
+            <DemoContainer components={["DateTimePicker"]}>
+              <DateTimePicker
+                value={deadline}
+                onChange={(newValue) => setDeadline(newValue)}
+                minDateTime={dayjs().add(30, "minute")}
+              />
+            </DemoContainer>
+          </LocalizationProvider>
+        </div>
+
+        <div className="form-group">
+          <label>심부름 희망 장소</label>
+          <input
+            type="text"
+            value={location}
+            placeholder="희망 장소를 입력하세요"
+            onChange={(e) => setLocation(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <button
+        className="task-detail-action-button"
+        disabled={!isFormValid}
+        onClick={handleSubmit}
+      >
+        결제하기
+      </button>
+    </div>
+  );
+}

--- a/src/pages/TaskWrite.js
+++ b/src/pages/TaskWrite.js
@@ -17,23 +17,43 @@ export default function TaskWrite() {
   const [amount, setAmount] = useState("");
   const [deadline, setDeadline] = useState(dayjs().add(30, "minute"));
   const [location, setLocation] = useState("");
+  const [description, setDescription] = useState("");
+  const [imageUrls, setImageUrls] = useState([]);
 
-  const handleImageChange = (e) => {
+  const handleImageChange = async (e) => {
     const files = Array.from(e.target.files).slice(0, 3);
     setImages(files);
+    if (files.length > 0) {
+      const formData = new FormData();
+      files.forEach((file) => formData.append("files", file));
+      try {
+        console.log("이미지 업로드 요청!!");
+        const uploadRes = await api.post("/api/files/images", formData);
+        setImageUrls(uploadRes.data.uploadedFileUrls || []);
+        console.log("Uploaded URLs:", uploadRes.data.uploadedFileUrls);
+        console.log("이미지 업로드 성공!!");
+      } catch (err) {
+        console.error("Image upload failed", err);
+        alert("이미지 업로드에 실패했습니다.");
+      }
+    } else {
+      setImageUrls([]);
+    }
   };
 
   const handleSubmit = async () => {
     if (!isFormValid) return;
     try {
+      // Build JSON request body
       const body = {
         title: title.trim(),
-        content: title.trim(), // TODO: 본문 입력 칸 추가 필요
+        content: description.trim(),
         deadline: deadline.format("YY.MM.DD HH:mm"),
         reward: Number(amount),
         address: location.trim(),
-        imageUrls: [], // TODO: 이미지 업로드 후 URL 배열로 대체
+        imageUrls,
       };
+      // Send as application/json
       const res = await api.post("/api/tasks/task", body);
       const { taskId, merchantUid, result } = res.data;
       if (result) {
@@ -49,6 +69,7 @@ export default function TaskWrite() {
 
   const isFormValid =
     title.trim() !== "" &&
+    description.trim() !== "" &&
     amount !== "" &&
     !isNaN(amount) &&
     Number(amount) >= 100 &&
@@ -112,6 +133,18 @@ export default function TaskWrite() {
               />
             </DemoContainer>
           </LocalizationProvider>
+        </div>
+
+        <div className="form-group">
+          <label>자세한 설명*</label>
+          <textarea
+            value={description}
+            placeholder="심부름의 세부 내용을 작성해주세요.
+신뢰할 수 있는 심부름을 위하여 자세히 작성해주세요.
+욕설이나 비방 등의 내용은 삭제 조치될 수 있습니다."
+            rows={4}
+            onChange={(e) => setDescription(e.target.value)}
+          />
         </div>
 
         <div className="form-group">

--- a/src/pages/TaskWrite.js
+++ b/src/pages/TaskWrite.js
@@ -12,7 +12,6 @@ import api from "../service/api";
 
 export default function TaskWrite() {
   const navigate = useNavigate();
-  const [images, setImages] = useState([]);
   const [title, setTitle] = useState("");
   const [amount, setAmount] = useState("");
   const [deadline, setDeadline] = useState(dayjs().add(30, "minute"));
@@ -22,7 +21,7 @@ export default function TaskWrite() {
 
   const handleImageChange = async (e) => {
     const files = Array.from(e.target.files).slice(0, 3);
-    setImages(files);
+    // setImages(files);
     if (files.length > 0) {
       const formData = new FormData();
       files.forEach((file) => formData.append("files", file));
@@ -55,7 +54,7 @@ export default function TaskWrite() {
       };
       // Send as application/json
       const res = await api.post("/api/tasks/task", body);
-      const { taskId, merchantUid, result } = res.data;
+      const { taskId, result } = res.data;
       if (result) {
         navigate(`/task/${taskId}`);
       } else {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Home";

--- a/src/styles/Home.module.css
+++ b/src/styles/Home.module.css
@@ -1,0 +1,80 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  border-bottom: 1px solid #ddd;
+}
+
+.logo {
+  width: 43px; /* 적절한 크기로 조절 */
+  height: 43px;
+  object-fit: contain;
+}
+
+.userArea {
+}
+
+.loginButton {
+  display: inline-block;
+  padding: 8px 24px; /* 좌우 여백을 넉넉히 줘서 타원형 느낌 연출 */
+  background-color: #a4b465; /* Fill */
+  color: #ffffff; /* Text Fill */
+  font-size: 14px; /* Font Size */
+  text-align: center; /* Text Alignment */
+  border: 2px solid #a4b465; /* Stroke (same 색상, 2px 두께) */
+  border-radius: 40px; /* Corner Radius */
+  box-sizing: border-box; /* Border가 내부로 계산되도록 */
+  cursor: pointer;
+  line-height: 1; /* 텍스트 수직 중앙 정렬 조정 시 필요시 수정 */
+}
+
+.userInfo {
+  font-size: 14px;
+  color: #333;
+}
+
+/* src/pages/Home/Home.module.css */
+
+.container {
+  padding: 16px;
+  position: relative; /* 버튼 absolute 위치 기준 */
+  padding-bottom: 200px;
+}
+
+/* Mobile: fixed positioning */
+@media (max-width: 390px) {
+  .writeButton {
+    position: fixed;
+    right: 10px;
+    bottom: 80px;
+  }
+}
+
+/* Desktop: fixed relative to viewport, aligned with container */
+@media (min-width: 391px) {
+  .writeButton {
+    position: fixed;
+    right: calc((100vw - 390px) / 2 + 16px);
+    bottom: 80px;
+  }
+}
+
+/* Shared button styles */
+.writeButton {
+  width: 127px;
+  height: 56px;
+  border-radius: 28px;
+  background-color: #a4b465;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: none;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.15);
+  cursor: pointer;
+  z-index: 1000;
+}

--- a/src/styles/Home.module.css
+++ b/src/styles/Home.module.css
@@ -1,9 +1,17 @@
 .header {
+  position: fixed;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 350px;
+  height: 55px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 16px;
+  padding: 20px;
   border-bottom: 1px solid #ddd;
+  background-color: #ffffff;
+  z-index: 100;
 }
 
 .logo {
@@ -38,6 +46,7 @@
 
 .container {
   padding: 16px;
+  padding-top: 100px;
   position: relative; /* 버튼 absolute 위치 기준 */
   padding-bottom: 200px;
 }

--- a/src/styles/TaskDetail.css
+++ b/src/styles/TaskDetail.css
@@ -1,0 +1,106 @@
+.task-detail-container {
+  width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
+  padding-bottom: 200px; /* 버튼 공간 확보 */
+  box-sizing: border-box;
+}
+
+.task-detail-header {
+  position: sticky;
+  top: 0;
+  background-color: #fff;
+  padding: 16px;
+  border-bottom: 1px solid #ddd;
+  z-index: 10;
+}
+
+.task-detail-back-button {
+  background: none;
+  border: none;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+.task-detail-image {
+  width: 100%;
+  height: 240px;
+  object-fit: cover;
+}
+
+.task-detail-content {
+  padding: 16px;
+}
+
+.task-detail-title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.task-detail-time {
+  margin: 2px 0 0 0;
+  font-size: 12px;
+  color: #555;
+}
+
+.task-detail-amount {
+  margin: 7px 0 0 0;
+  font-size: 16px;
+  font-weight: bold;
+}
+
+.task-detail-location {
+  margin: 7px 0 0 0;
+  font-size: 12px;
+  color: #555;
+}
+
+.task-detail-description {
+  margin: 16px 0 0 0;
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre-line;
+}
+
+.task-detail-action-button {
+  width: 127px;
+  height: 56px;
+  border-radius: 28px;
+  background-color: #626f47;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: none;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  cursor: pointer;
+  z-index: 1000;
+}
+
+/* Mobile: fixed positioning */
+@media (max-width: 390px) {
+  .task-detail-action-button {
+    position: fixed;
+    right: 10px;
+    bottom: 80px;
+  }
+}
+
+/* Desktop: fixed relative to viewport, aligned with container */
+@media (min-width: 391px) {
+  .task-detail-action-button {
+    position: fixed;
+    right: calc((100vw - 390px) / 2 + 16px);
+    bottom: 80px;
+  }
+}
+
+.task-detail-action-button.disabled {
+  background-color: #cecece;
+  pointer-events: none; /* 클릭 비활성화 */
+  cursor: default; /* 커서 변경 */
+}

--- a/src/styles/TaskItem.module.css
+++ b/src/styles/TaskItem.module.css
@@ -1,0 +1,33 @@
+.container {
+  display: flex;
+  align-items: center;
+  padding: 12px;
+  margin-bottom: 12px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.thumbnail {
+  width: 80px;
+  height: 80px;
+  border-radius: 4px;
+  object-fit: cover;
+  margin-right: 12px;
+}
+
+.info {
+  flex: 1;
+}
+
+.title {
+  margin: 0 0 8px;
+  font-size: 16px;
+  font-weight: bold;
+}
+
+.meta {
+  margin: 0;
+  font-size: 12px;
+  color: #555;
+}

--- a/src/styles/TaskWrite.css
+++ b/src/styles/TaskWrite.css
@@ -1,0 +1,93 @@
+/* Container and header */
+.task-detail-container {
+  width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
+  padding-bottom: 200px; /* 버튼 공간 확보 */
+  box-sizing: border-box;
+}
+
+.task-detail-header {
+  position: sticky;
+  top: 0;
+  background-color: #fff;
+  padding: 16px;
+  border-bottom: 1px solid #ddd;
+  z-index: 10;
+}
+
+.task-detail-back-button {
+  background: none;
+  border: none;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+/* Form container */
+.task-write-container {
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 24px;
+}
+
+.form-group label {
+  margin-bottom: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #333;
+}
+
+.form-group input {
+  padding: 8px 12px;
+  font-size: 14px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+/* Action button */
+.task-detail-action-button {
+  width: 127px;
+  height: 56px;
+  border-radius: 28px;
+  background-color: #626f47; /* 활성 상태 색상 */
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: none;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  cursor: pointer;
+  z-index: 1000;
+}
+
+@media (max-width: 390px) {
+  .task-detail-action-button {
+    position: fixed;
+    right: 10px;
+    bottom: 80px;
+  }
+}
+
+@media (min-width: 391px) {
+  .task-detail-action-button {
+    position: fixed;
+    right: calc((100vw - 390px) / 2 + 16px);
+    bottom: 80px;
+  }
+}
+
+.task-detail-action-button.disabled {
+  background-color: #cecece; /* 비활성 상태 색상 */
+  pointer-events: none;
+  cursor: default;
+}


### PR DESCRIPTION
📑 작업 상세 내용
- 메인페이지 화면 구현 했습니다
  - 로그인 여부에 따른 심부름 요청 목록 관심 지역(비로그인:강남구 대치2동 / 로그인: 사용자 관심지역) 갖고 오도록 구현했습니다.
  - 로그인과 연결 했습니다.
  - 심부름 작성 페이지와 연결했습니다.
- 심부름 작성 페이지 화면 구현했습니다.
  - 이미지 업로드 API와 심부름 작성 API 연결은 완료한 상태입니다.
- 심부름 상세 페이지 화면 구했습니다.
  - 상세 페이지 API는 아직 미연결입니다.


💫 작업 요약
- 메인페이지 화면 구현 했습니다
- 심부름 작성 페이지 화면 구현했습니다.
- 심부름 상세 페이지 화면 구했습니다.


🔍 집중적으로 리뷰할 부분 (확인 및 점검 사항)
mui 관련 라이브러리 오류나면 아래 명령어로 설치해주세요!
- npm install @mui/x-date-pickers
- npm install dayjs

참고 자료(선택)