### PR TITLE
Feat: 로그아웃, 토큰 재발급

### DIFF
--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -18,6 +18,22 @@ const MyPage = () => {
     navigate("/extra-info", { state: { isEditMode: true } });
   };
 
+  const handleLogout = () => {
+    if (window.confirm("로그아웃 하시겠습니까?")) {
+      api
+        .post("/api/auth/logout")
+        .then(() => {
+          localStorage.removeItem("accessToken");
+          localStorage.removeItem("refreshToken");
+          navigate("/login");
+        })
+        .catch((err) => {
+          console.error("로그아웃 실패:", err);
+          alert("로그아웃 중 오류가 발생했습니다.");
+        });
+    }
+  };
+
   useEffect(() => {
     const fetchUserInfo = () => {
       api
@@ -88,7 +104,9 @@ const MyPage = () => {
         </div>
       </div>
 
-      <button className="logout-button">로그아웃</button>
+      <button className="logout-button" onClick={handleLogout}>
+        로그아웃
+      </button>
     </div>
   );
 };

--- a/src/service/api.js
+++ b/src/service/api.js
@@ -1,24 +1,79 @@
 // src/service/api.js
-import axios from 'axios';
+import axios from "axios";
+
+const API_URL = process.env.REACT_APP_API_URL;
+if (!API_URL) {
+  throw new Error("REACT_APP_API_URL is not defined");
+}
 
 /**
  * Axios 인스턴스 설정
  */
 const api = axios.create({
-  baseURL: process.env.REACT_APP_API_URL || 'http://localhost:8080',
+  baseURL: API_URL,
   timeout: 5000,
 });
 
-// 요청 인터셉터: JWT 토큰 자동 추가 등 공통 로직
+// 요청 인터셉터: 토큰이 있으면 헤더에 추가
 api.interceptors.request.use(
-  config => {
-    const token = localStorage.getItem('accessToken');
+  (config) => {
+    const token = localStorage.getItem("accessToken");
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
     return config;
   },
-  error => Promise.reject(error)
+  (error) => Promise.reject(error)
+);
+
+// 응답 인터셉터: 토큰 만료 시 재발급
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    // 토큰 만료 에러이고, 재시도하지 않은 요청인 경우
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      try {
+        // 리프레시 토큰으로 새로운 토큰 발급
+        const refreshToken = localStorage.getItem("refreshToken");
+        const res = await axios.post(
+          `${API_URL}/api/auth/reissue`,
+          {},
+          {
+            headers: {
+              Authorization: `Bearer ${refreshToken}`,
+            },
+          }
+        );
+
+        // 새로운 토큰 저장
+        const { accessToken } = res.data;
+        localStorage.setItem("accessToken", accessToken);
+
+        // 새로운 토큰으로 원래 요청 재시도
+        originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+        return api(originalRequest);
+      } catch (refreshError) {
+        // 리프레시 토큰도 만료된 경우 로그아웃 처리
+        localStorage.removeItem("accessToken");
+        localStorage.removeItem("refreshToken");
+        window.location.href = "/login";
+        return Promise.reject(refreshError);
+      }
+    }
+
+    // 401 에러가 아닌 경우
+    if (error.response?.status === 403) {
+      // 권한 없는 경우
+      window.location.href = "/";
+      return Promise.reject(error);
+    }
+
+    return Promise.reject(error);
+  }
 );
 
 export default api;


### PR DESCRIPTION
## 📑 작업 상세 내용
로그아웃
- 로그아웃 시 db와 localStorage에 저장된 토큰 삭제
토큰 재밝급
- 401에러 발생 시 refreshToken으로 새로운 accessToken 요청
- 새 토큰 받으면 localStorage에 저장하고 실패한 요청 재시도
- 토큰 재발급 실패 시 로그아웃 처리
- 403에러 발생 시 메인 페이지로 리다이렉트

## 💫 작업 요약
마이페이지에서 로그아웃 버튼 클릭 시 로그아웃 기능 수행
accessToken 만료시 토큰 재발급 수행

## 🔍 집중적으로 리뷰할 부분 (확인 및 점검 사항) 

## 참고 자료(선택) 