### PR TITLE
Fix: 메인페이지 심부름 요청 목록 API 무한 요청 문제 해결

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -43,12 +43,12 @@ export default function Home() {
       setHasNext(next);
     } catch (err) {
       console.error("Failed to load tasks", err);
+      setHasNext(false);
     } finally {
       setIsLoading(false);
     }
   }, [cursor, hasNext, isLoading]);
 
-  // fetch user profile once
   useEffect(() => {
     api
       .get("/api/users/user/profile")
@@ -63,12 +63,10 @@ export default function Home() {
       });
   }, []);
 
-  // initial load
   useEffect(() => {
     loadPosts();
-  }, [loadPosts, hasNext, isLoading]);
+  }, []);
 
-  // infinite scroll
   useEffect(() => {
     const onScroll = () => {
       if (
@@ -82,7 +80,7 @@ export default function Home() {
     };
     window.addEventListener("scroll", onScroll);
     return () => window.removeEventListener("scroll", onScroll);
-  }, [loadPosts, hasNext, isLoading]);
+  }, [loadPosts]);
 
   return (
     <>

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useCallback, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import TaskItem from "../components/TaskItem/TaskItem";
 import styles from "../styles/Home.module.css";
@@ -16,9 +16,12 @@ export default function Home() {
   const [cursor, setCursor] = useState(null);
   const [hasNext, setHasNext] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
+  const hasNextRef = useRef(hasNext);
+  const isLoadingRef = useRef(isLoading);
+  const loadPostsRef = useRef(null);
 
   const loadPosts = useCallback(async () => {
-    if (!hasNext || isLoading) return;
+    if (!hasNextRef.current || isLoadingRef.current) return;
     setIsLoading(true);
     try {
       const params = { size: PAGE_SIZE };
@@ -27,8 +30,8 @@ export default function Home() {
       }
 
       const res = await api.get("/api/tasks", { params });
-      const { items = [], nextCursor, hasNext: next } = res.data;
-      console.log("Fetched tasks data:", res.data);
+      const { items = [], nextCursor } = res.data;
+      const nextHas = items.length === PAGE_SIZE;
 
       const mapped = items.map((item) => ({
         id: item.taskId,
@@ -40,14 +43,26 @@ export default function Home() {
 
       setPosts((prev) => [...prev, ...mapped]);
       setCursor(nextCursor);
-      setHasNext(next);
+      setHasNext(nextHas);
     } catch (err) {
       console.error("Failed to load tasks", err);
       setHasNext(false);
     } finally {
       setIsLoading(false);
     }
-  }, [cursor, hasNext, isLoading]);
+  }, [cursor]);
+
+  useEffect(() => {
+    hasNextRef.current = hasNext;
+  }, [hasNext]);
+
+  useEffect(() => {
+    isLoadingRef.current = isLoading;
+  }, [isLoading]);
+
+  useEffect(() => {
+    loadPostsRef.current = loadPosts;
+  }, [loadPosts]);
 
   useEffect(() => {
     api
@@ -64,23 +79,23 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
-    loadPosts();
+    loadPostsRef.current();
   }, []);
 
   useEffect(() => {
     const onScroll = () => {
       if (
-        hasNext &&
-        !isLoading &&
+        hasNextRef.current &&
+        !isLoadingRef.current &&
         window.innerHeight + window.pageYOffset + 100 >=
           document.body.offsetHeight
       ) {
-        loadPosts();
+        loadPostsRef.current();
       }
     };
     window.addEventListener("scroll", onScroll);
     return () => window.removeEventListener("scroll", onScroll);
-  }, [loadPosts]);
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
## 📑 작업 상세 내용
- 메인 페이지
  - 심부름 요청 목록 API 무한 요청 문제 해결
  - 심부름 요청 목록 API에서 스크롤을 내리지 않아도 한번에 모든 페이지네이션을 진행하는 문제 해결


## 💫 작업 요약
- 심부름 요청 목록 API 무한 요청 문제 해결
- 심부름 요청 목록 API 스크롤과 연계되지 않는 문제 해결

## 🔍 집중적으로 리뷰할 부분 (확인 및 점검 사항) 

## 참고 자료(선택) 