### PR TITLE
feat #39: 요청/수행내역에서 navigate 추가

### DIFF
--- a/src/pages/PerformedTasks.jsx
+++ b/src/pages/PerformedTasks.jsx
@@ -88,7 +88,13 @@ export default function PerformedTasks() {
       {/* 본문 */}
       <div ref={containerRef} style={{ padding: "16px", paddingTop: "70px" }}>
         {tasks.map((post) => (
-          <TaskItem key={post.id} post={post} />
+          <div
+            key={post.id}
+            onClick={() => navigate(`/task/${post.id}`)}
+            style={{ cursor: "pointer" }}
+          >
+            <TaskItem post={post} />
+          </div>
         ))}
         {isLoadingRef.current && (
           <p style={{ textAlign: "center", marginTop: "16px" }}>

--- a/src/pages/RequestedTasks.jsx
+++ b/src/pages/RequestedTasks.jsx
@@ -88,7 +88,13 @@ export default function RequestedTasks() {
       {/* 본문 */}
       <div ref={containerRef} style={{ padding: "16px", paddingTop: "70px" }}>
         {tasks.map((post) => (
-          <TaskItem key={post.id} post={post} />
+          <div
+            key={post.id}
+            onClick={() => navigate(`/task/${post.id}`)}
+            style={{ cursor: "pointer" }}
+          >
+            <TaskItem post={post} />
+          </div>
         ))}
         {isLoadingRef.current && (
           <p style={{ textAlign: "center", marginTop: "16px" }}>


### PR DESCRIPTION
## 📑 작업 상세 내용
요청/수행내역에서 특정 심부름 선택 시 해당 심부름 상세 페이지로 이동되도록 하였습니다 

## 💫 작업 요약
RequestedTasks.jsx와 PerfomedTasks.jsx에 상세 페이지로 이동하는 로직 추가하였습니다. 

## 🔍 집중적으로 리뷰할 부분 (확인 및 점검 사항) 

## 참고 자료(선택) 